### PR TITLE
feat: ポイント操作ボタンをノード選択時にノード近くに表示する

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,9 @@
       <EthicsMapView
         :nodes="map.nodes"
         :selected-node-id="selectedNodeId"
+        :distributing="distributing"
         @node-selected="onNodeSelected"
+        @add-point="addPoint"
         @remove-point="removePoint"
       />
       <div class="sidebar">
@@ -13,11 +15,8 @@
         <PointControls
           :p-points="pNode.points"
           :distributing="distributing"
-          :selected-node-id="selectedNodeId"
           @start="startDistribution"
           @add-to-p="addToP"
-          @add-point="addPoint"
-          @remove-point="removePoint"
           @reset="reset"
           @copy-url="copyUrl"
         />

--- a/src/components/EthicsMapView.vue
+++ b/src/components/EthicsMapView.vue
@@ -54,6 +54,28 @@
         />
       </g>
 
+      <!-- 選択ノード近くのポイント操作ボタン -->
+      <foreignObject
+        v-if="distributing && selectedMapNode"
+        :x="selectedMapNode.x - 35"
+        :y="selectedMapNode.y + 22"
+        width="72"
+        height="30"
+      >
+        <div style="display:flex;gap:4px;">
+          <button
+            data-testid="add-point"
+            style="font-size:12px;padding:2px 6px;cursor:pointer;"
+            @click.stop="$emit('add-point', selectedNodeId)"
+          >+1</button>
+          <button
+            data-testid="remove-point"
+            style="font-size:12px;padding:2px 6px;cursor:pointer;"
+            @click.stop="$emit('remove-point', selectedNodeId)"
+          >-1</button>
+        </div>
+      </foreignObject>
+
       <!-- Pノード (左側) -->
       <g
         :data-testid="`node-P`"
@@ -81,9 +103,10 @@ import { computed } from 'vue'
 const props = defineProps({
   nodes: { type: Array, required: true },
   selectedNodeId: { type: String, default: null },
+  distributing: { type: Boolean, default: false },
 })
 
-defineEmits(['node-selected', 'remove-point'])
+defineEmits(['node-selected', 'remove-point', 'add-point'])
 
 const size = 440
 const cx = 220
@@ -193,6 +216,10 @@ const pNode = computed(() => {
 function tokenX(i, total) {
   return (i - (total + 1) / 2) * 10
 }
+
+const selectedMapNode = computed(() =>
+  mapNodes.value.find(n => n.id === props.selectedNodeId)
+)
 </script>
 
 <style scoped>

--- a/src/components/PointControls.vue
+++ b/src/components/PointControls.vue
@@ -11,20 +11,6 @@
 
     <template v-else>
       <button data-testid="add-point-to-p" @click="$emit('add-to-p')">ポイント追加 (+5)</button>
-      <button
-        v-if="selectedNodeId && selectedNodeId !== 'P'"
-        data-testid="add-point"
-        @click="$emit('add-point', selectedNodeId)"
-      >
-        {{ selectedNodeId }} に +1
-      </button>
-      <button
-        v-if="selectedNodeId && selectedNodeId !== 'P'"
-        data-testid="remove-point"
-        @click="$emit('remove-point', selectedNodeId)"
-      >
-        {{ selectedNodeId }} に -1
-      </button>
       <button data-testid="reset" @click="showConfirm = true">リセット</button>
 
       <div class="share-section">
@@ -52,10 +38,9 @@ import { ref } from 'vue'
 defineProps({
   pPoints: { type: Number, required: true },
   distributing: { type: Boolean, required: true },
-  selectedNodeId: { type: String, default: null },
 })
 
-const emit = defineEmits(['start', 'add-to-p', 'add-point', 'remove-point', 'reset', 'copy-url'])
+const emit = defineEmits(['start', 'add-to-p', 'reset', 'copy-url'])
 const showConfirm = ref(false)
 const userName = ref('')
 const copyLabel = ref('URLをコピー')


### PR DESCRIPTION
## Summary
- ノードを選択すると+1/-1ボタンがそのノードの近くにSVG内で表示される
- 選択解除でボタンが消える
- 別ノードを選択するとボタンが移動する

Closes #2

Generated with [Claude Code](https://claude.ai/code)