### PR TITLE
feat: ノード名ラベルを表示する (#20)

### DIFF
--- a/e2e/ethics-map.spec.js
+++ b/e2e/ethics-map.spec.js
@@ -60,6 +60,16 @@ test('UC006: トークンをクリックするとポイントが減る', async (
   await expect(page.locator('[data-testid="p-points"]')).toContainText('10')
 })
 
+test('UC008: 各ノードにラベルが表示される', async ({ page }) => {
+  await page.goto('/')
+  // 通常ノードはラベルがノードの下に表示される
+  await expect(page.locator('[data-testid="node-label-N0"]')).toBeVisible()
+  await expect(page.locator('[data-testid="node-label-N0"]')).toContainText('倫理的考慮')
+  await expect(page.locator('[data-testid="node-label-N1-1"]')).toContainText('安全性')
+  // Pノードはラベルがノードの上に表示される
+  await expect(page.locator('[data-testid="node-label-P"]')).toContainText('利益優先')
+})
+
 test('UC007: Pノードをクリックすると説明パネルにPノードのタイトルが表示される', async ({ page }) => {
   await page.goto('/')
   await page.locator('[data-testid="node-P"]').click()

--- a/src/components/EthicsMapView.vue
+++ b/src/components/EthicsMapView.vue
@@ -93,13 +93,22 @@
           />
           <ellipse cx="-1.8" cy="-2.8" rx="1.6" ry="0.9" fill="white" fill-opacity="0.45" transform="rotate(-25,-1.8,-2.8)"/>
         </g>
+        <text
+          :data-testid="`node-label-${node.id}`"
+          text-anchor="middle"
+          dominant-baseline="hanging"
+          font-size="10"
+          fill="#333"
+          y="24"
+          style="pointer-events: none"
+        >{{ node.title }}</text>
       </g>
 
       <!-- 選択ノード近くのポイント操作ボタン -->
       <foreignObject
         v-if="distributing && selectedMapNode"
         :x="selectedMapNode.x - 35"
-        :y="selectedMapNode.y + 22"
+        :y="selectedMapNode.y + 40"
         width="72"
         height="30"
       >
@@ -126,6 +135,15 @@
         style="cursor: pointer"
         @click="$emit('node-selected', 'P')"
       >
+        <text
+          data-testid="node-label-P"
+          text-anchor="middle"
+          dominant-baseline="auto"
+          font-size="10"
+          fill="#333"
+          y="-108"
+          style="pointer-events: none"
+        >{{ pNode.title }}</text>
         <rect x="-45" y="-100" width="90" height="200" rx="12" :fill="pNode.color" stroke="#999" stroke-width="1.5" />
         <template v-if="distributing">
           <g


### PR DESCRIPTION
#20 の実装。

各ノードのタイトルをSVG上に表示する。Pノードは上、その他は下に表示。+/-ボタンはラベルのさらに下に移動。

Generated with [Claude Code](https://claude.ai/code)